### PR TITLE
Use named field for startup *.MER file

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -228,8 +228,7 @@ class Window(tk.Frame):
             try:
                 meu = MEUtility(ip_address)
                 stuff = meu.get_terminal_info()
-                temp = stuff.device.log[-1]
-                temp = temp.split("\\")[-1][:-1]
+                temp = stuff.device.startup_mer_file
                 if temp.endswith(".mer"):
                     running_file = temp
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 olefile
 pylogix
-pymeu
+pymeu>=0.1.11


### PR DESCRIPTION
In the latest release there should be a named field that can be used instead of parsing the log messages.
That way hopefully I don't break anything by changes to the log messages / ordering.